### PR TITLE
Add MachineAutoscaler configs so all module labs will work 

### DIFF
--- a/content/modules/ROOT/pages/200-ops/lab_5_observability.adoc
+++ b/content/modules/ROOT/pages/200-ops/lab_5_observability.adoc
@@ -4,6 +4,51 @@ Azure Red Hat OpenShift (ARO) clusters store log data inside the cluster by defa
 
 In this section of the workshop, we'll configure ARO to forward logs and metrics to Azure Files and view them using Grafana.
 
+== Configure Autoscaling for All Worker MachineSets
+
+OpenShift Cluster Logging takes place in the cluster itself, so we need to scale up the number of worker nodes.
+We'll use the MachineAutoscaler on each of the existing MachineSets to scale up the number of worker nodes.
+
+. To deploy the MachineAutoscalers, run the following command:
++
+[source,sh,role=execute]
+----
+MACHINESETS=$(oc -n openshift-machine-api get machinesets -o name | cut -d / -f2 )
+
+for MACHINESET in $(echo ${MACHINESETS}); do
+cat <<EOF | oc apply -f -
+---
+apiVersion: "autoscaling.openshift.io/v1beta1"
+kind: "MachineAutoscaler"
+metadata:
+  name: "${MACHINESET}"
+  namespace: "openshift-machine-api"
+spec:
+  minReplicas: 1
+  maxReplicas: 3
+  scaleTargetRef:
+    apiVersion: machine.openshift.io/v1beta1
+    kind: MachineSet
+    name: "${MACHINESET}"
+EOF
+done
+----
+
+CAUTION: Be patient with this lab.
+As you progress through this lab deploying logging be aware that it will take about five minutes to provision each machine and another one minute for the Nodes to become Ready.
+
+. Be prepareed to watch the progress of the MachineAutoscaler as you work through this lab with the following commands.
+.. Get the list of Pods in state "Pending", which triggers the MachineAutoscaler to scale up the number of worker nodes
+.. Get the list of Machines in the cluster, which you will see in various states as they are being provisioned
+.. Get the list of Nodes as they become ready and the Pods in Pending are deployed to them
++
+[source,sh,role=execute]
+----
+oc get pods -A | grep Pending
+oc -n openshift-machine-api get machines -l "machine.openshift.io/cluster-api-machine-role=worker"
+oc get nodes -o wide
+----
+
 == Configure Metrics and Log Forwarding to Azure Files
 
 . First, let's create our Azure Files storage account. To do so, run the following command::

--- a/content/modules/ROOT/pages/300-apps/lab_2_openshift_gitops.adoc
+++ b/content/modules/ROOT/pages/300-apps/lab_2_openshift_gitops.adoc
@@ -2,7 +2,7 @@
 
 Red Hat OpenShift GitOps is an operator that provides a workflow that integrates git repositories, continuous integration/continuous delivery (CI/CD) tools, and Kubernetes to realize faster, more secure, scalable software development, without compromising quality.
 
-OpenShift GitOps enables customers to build and integrate declarative git driven CD workflows directly into their application development platform. 
+OpenShift GitOps enables customers to build and integrate declarative git driven CD workflows directly into their application development platform.
 
 There's no single tool that converts a development pipeline to "DevOps". By implementing a GitOps framework, updates and changes are pushed through declarative code, automating infrastructure and deployment requirements, and CI/CD.
 
@@ -84,7 +84,12 @@ EOF
 ----
 argocd.argoproj.io/argocd created
 ----
-
++
+WARNING: ArgoCD deployment will require additional Worker nodes.
+The MachineAutoscalers will create the Worker machines and nodes automatically.
+Watch progress of the MachineAutoscaler as follows: `oc get pods -A | grep Pending; oc -n openshift-machine-api get machines; oc get nodes`
+*This process will take about six minutes.*
++
 . Wait for ArgoCD to be ready
 +
 [source,sh,role=execute]
@@ -244,7 +249,7 @@ deployment.apps/bgd patched
 The self healing may happen so fast you don't even see it happen. If you missed just run the command again and be sure to have the Argo CD view up and ready!
 ====
 
-== Summary 
+== Summary
 
 Here you learned how to:
 


### PR DESCRIPTION
Addresses Issue #16

The default cluster doesn't have enough workers to run all the module labs.

This adds MachineAutoscalers to all the MachineSets so they'll scale automatically to meet the need.
