### PR TITLE
Update lab_3_service_mesh_deploy_control_plane.adoc

### DIFF
--- a/content/modules/ROOT/pages/400-service-mesh/lab_3_service_mesh_deploy_control_plane.adoc
+++ b/content/modules/ROOT/pages/400-service-mesh/lab_3_service_mesh_deploy_control_plane.adoc
@@ -40,7 +40,7 @@ metadata:
   name: basic
   namespace: istio-system
 spec:
-  version: v2.2
+  version: v2.6
   security:
     identity:
       type: ThirdParty


### PR DESCRIPTION
Fix service mesh version in CRD.  Version 2.2 is no longer valid.